### PR TITLE
Create multiple files at once

### DIFF
--- a/lua/dirbuf.lua
+++ b/lua/dirbuf.lua
@@ -330,8 +330,15 @@ function M.sync(opt)
 
   local dir = api.nvim_buf_get_name(CURRENT_BUFFER)
   local lines = api.nvim_buf_get_lines(CURRENT_BUFFER, 0, -1, true)
+  local expanded_lines = {}
+  for _, line in ipairs(lines) do
+      local paths = buffer.expand_path(line)
+      for _, path in ipairs(paths) do
+          table.insert(expanded_lines, path)
+      end
+  end
   local changes
-  err, changes = planner.build_changes(dir, vim.b.dirbuf, lines)
+  err, changes = planner.build_changes(dir, vim.b.dirbuf, expanded_lines)
   if err ~= nil then
     api.nvim_err_writeln(err)
     return

--- a/lua/dirbuf/buffer.lua
+++ b/lua/dirbuf/buffer.lua
@@ -265,4 +265,3 @@ function M.expand_path(path)
 end
 
 return M
-

--- a/lua/dirbuf/buffer.lua
+++ b/lua/dirbuf/buffer.lua
@@ -226,4 +226,43 @@ function M.get_fs_entries(dir, show_hidden)
   return nil, fs_entries
 end
 
+function M.expand_path(path)
+  -- table to store paths that have not yet been fully expanded, this table
+  -- will grow depending on how many expansion groups are in the original path
+  -- argument
+  local unresolved = {path}
+  local i = 1
+
+  -- table to store fully expanded paths
+  local paths = {}
+
+  for _, current in ipairs(unresolved) do
+
+    -- find the start and end of expansion group range
+    local lbracket, rbracket = current:find('{[^}]+}')
+
+    -- fully expanded/resolved current path
+    if lbracket == nil or rbracket == nil then
+      table.insert(paths, current)
+    else
+      -- prefix (before the expansion group)
+      local prefix = current:sub(1, lbracket - 1)
+
+      -- suffix (after the expansion group)
+      local suffix = current:sub(rbracket + 1, #current)
+
+      -- expansion group (what to expand into multiple filenames)
+      local egroup = current:sub(lbracket + 1, rbracket - 1)
+
+      -- each group in the expansion group (ex. {.txt,.c} -> .txt and .c)
+      for expansion in egroup:gmatch("[^,]+") do
+        table.insert(unresolved, prefix .. expansion .. suffix)
+      end
+    end
+    i = i + 1
+  end
+  return paths
+end
+
 return M
+

--- a/lua/dirbuf/planner.lua
+++ b/lua/dirbuf/planner.lua
@@ -179,20 +179,20 @@ end
 --
 -- Returns: list of actions as in fs.plan
 function M.determine_plan(changes)
-    local plan = {}
+  local plan = {}
 
-    for _, change in pairs(changes.change_map) do
-        local extra_action = resolve_change(plan, changes.change_map, change)
-        if extra_action ~= nil then
-            table.insert(plan, extra_action)
-        end
+  for _, change in pairs(changes.change_map) do
+    local extra_action = resolve_change(plan, changes.change_map, change)
+    if extra_action ~= nil then
+      table.insert(plan, extra_action)
     end
+  end
 
-    for _, fs_entry in ipairs(changes.new_files) do
-        table.insert(plan, create(fs_entry))
-    end
+  for _, fs_entry in ipairs(changes.new_files) do
+    table.insert(plan, create(fs_entry))
+  end
 
-    return plan
+  return plan
 end
 
 -- `execute_plan` executes the plan (i.e. sequence of actions) as created by

--- a/lua/dirbuf/planner.lua
+++ b/lua/dirbuf/planner.lua
@@ -174,6 +174,45 @@ local function resolve_change(plan, change_map, change)
   return post_resolution_action
 end
 
+local function expand_path(path)
+  -- table to store paths that have not yet been fully expanded, this table
+  -- will grow depending on how many expansion groups are in the original path
+  -- argument
+  local unresolved = {path}
+  local i = 1
+
+  -- table to store fully expanded paths
+  local paths = {}
+
+  while i <= #unresolved do
+    local current = unresolved[i]
+
+    -- find the start and end of expansion group range
+    local istart, iend = current:find('{[^}]+}')
+
+    -- fully expanded/resolved current path
+    if istart == nil or iend == nil then
+      table.insert(paths, current)
+    else
+      -- prefix (before the expansion group)
+      local prefix = current:sub(1, istart - 1)
+
+      -- suffix (after the expansion group)
+      local suffix = current:sub(iend + 1, #current)
+
+      -- expansion group (what to expand into multiple filenames)
+      local egroup = current:sub(istart + 1, iend - 1)
+
+      -- each group in the expansion group (ex. {.txt,.c} -> .txt and .c)
+      for expansion in string.gmatch(egroup, "[^,]+") do
+        table.insert(unresolved, prefix .. expansion .. suffix)
+      end
+    end
+    i = i + 1
+  end
+  return paths
+end
+
 -- `determine_plan` finds the most efficient sequence of actions necessary to
 -- apply the set of validated changes we have `changes`.
 --
@@ -189,7 +228,19 @@ function M.determine_plan(changes)
   end
 
   for _, fs_entry in ipairs(changes.new_files) do
-    table.insert(plan, create(fs_entry))
+    local fnames = expand_path(fs_entry.fname)
+    local paths = expand_path(fs_entry.path)
+
+    for i=1,#fnames do
+      table.insert(plan, create({
+        fname = fnames[i],
+        ftype = fs_entry.ftype,
+        path = paths[i]
+      }))
+    end
+
+--     print(vim.inspect(fnames))
+--     print(vim.inspect(fs_entry))
   end
 
   return plan


### PR DESCRIPTION
[Issue #37] Added ability to create multiple files at once using expansion groups.

Example:
test{.c,.txt,.py} => test.c, test.txt, test.py
test{1,2}_test{3,4}/ => test1_test3/, test1_test4/, test2_test3/
test2_test4/

Multiple expansion groups can be in the same filename.

This still does not allow nested directories to be created however.