### PR TITLE
Add nvim-web-devicon support

### DIFF
--- a/lua/dirbuf/config.lua
+++ b/lua/dirbuf/config.lua
@@ -51,6 +51,14 @@ local CONFIG_SPEC = {
       end
     end,
   },
+  devicons = {
+    default = false,
+    check = function(val)
+      if type(val) ~= "boolean" then
+        return "must be boolean, received " .. type(val)
+      end
+    end,
+  },
 }
 
 local user_config = {}

--- a/lua/dirbuf/config.lua
+++ b/lua/dirbuf/config.lua
@@ -54,6 +54,9 @@ local CONFIG_SPEC = {
   devicons = {
     default = false,
     check = function(val)
+      if require('dirbuf.devicons').has_devicons() ~= true and val == true then
+        return "nvim-web-devicons not installed"
+      end
       if type(val) ~= "boolean" then
         return "must be boolean, received " .. type(val)
       end

--- a/lua/dirbuf/devicons/init.lua
+++ b/lua/dirbuf/devicons/init.lua
@@ -2,15 +2,16 @@
 Support for nvim-web-devicons
 --]]
 
-local devicons = require('nvim-web-devicons')
 
 local M = {}
 
 function M.has_devicons()
-  return assert(devicons.has_loaded(), "Devicons not found for dirbuf.nvim")
+  local ok, has = pcall(require, "nvim-web-devicons")
+  return ok
 end
 
 function M.get_icon(fname, ftype)
+  local devicons = require('nvim-web-devicons')
   if ftype == "file" then
     local ext = vim.fn.fnamemodify(fname, ":e")
     return devicons.get_icon(fname, ext, {default = true})

--- a/lua/dirbuf/devicons/init.lua
+++ b/lua/dirbuf/devicons/init.lua
@@ -1,0 +1,24 @@
+--[[
+Support for nvim-web-devicons
+--]]
+
+local devicons = require('nvim-web-devicons')
+
+local M = {}
+
+function M.has_devicons()
+  return assert(devicons.has_loaded(), "Devicons not found for dirbuf.nvim")
+end
+
+function M.get_icon(fname, ftype)
+  if ftype == "file" then
+    local ext = vim.fn.fnamemodify(fname, ":e")
+    return devicons.get_icon(fname, ext, {default = true})
+  elseif ftype == "directory" then
+    return ""
+  else
+    return devicons.get_icon(fname, "", {default = true})
+  end
+end
+
+return M


### PR DESCRIPTION
I like how devicons look, and noticed that the feature was lacking here. This PR features support for the popular Neovim devicon plugin [nvim-web-devicons](https://github.com/kyazdani42/nvim-web-devicons)

Overview: the feature is disabled by default, to enable use the boolean key "devicons" inside your setup table. This will warn about if said devicon plugin is installed when `devicon = true`. All features currently present to dirbuf work with my testing. With devicons on, the line parser skips the icon and proceeding space after to grab the file name, leading to the same compatibility

Still getting used to this code base, so please let me know of anything that needs fixing. I would like to use the colors of nvim-web-devicons hl groups that plugins such as Telescope or fzf-lua achieve, but I need to break down how this plugin works more